### PR TITLE
fix counting the segments

### DIFF
--- a/HB-OU-RGBW-LED-FX.ino
+++ b/HB-OU-RGBW-LED-FX.ino
@@ -502,13 +502,13 @@ void calculateLedCount() {
     channel2segnum[i] = segmentNumber;
 
     if (ledCount < 1024) {
-      segmentStart[segmentNumber] = (segmentNumber == 0) ? 0 :  segmentEnd[segmentNumber - 1];
+      segmentStart[segmentNumber] = (segmentNumber == 0) ? 0 :  segmentEnd[segmentNumber - 1] + 1;
       segmentEnd  [segmentNumber] = segmentStart[segmentNumber] + ledCount - 1;
       totalLeds += ledCount;
       if (nextLedCount < 1024) segmentNumber++;
     }
   }
-  segmentCount = segmentNumber;
+  segmentCount = segmentNumber + 1;
   segmentState[segmentNumber] = 0;
   ws2812fx.updateLength(totalLeds);
   dumpLedStripe();

--- a/HB-OU-RGBW-LED-FX.ino
+++ b/HB-OU-RGBW-LED-FX.ino
@@ -49,6 +49,17 @@
   #define CC1101_GDO0        10  //PD2
 #endif
 
+#ifdef __AVR_ATmega1284P__       //Pin Definitionen (when using 128P: use Standard Pinout)
+                                 //on deimos' HB-UNI-644
+  #define CONFIG_BUTTON_PIN  13  //PD5
+  #define WSLED_PIN          18  //PC2
+  #define WSLED_ACTIVATE_PIN 20  //PC4
+  #define ONBOARD_LED_PIN1    0  //PB0
+  #define ONBOARD_LED_PIN2    1  //PB1
+  #define CC1101_CS           4  //PB4
+  #define CC1101_GDO0        10  //PD2
+#endif
+
 #ifdef ARDUINO_ARCH_ESP32
   #define CONFIG_BUTTON_PIN   16
   #define WSLED_PIN           21


### PR DESCRIPTION
Setup:
3 segments with 30, 20, 10 LEDs

Debug output from mainline:
```
Channel 1 belongs to segment 0
Channel 2 belongs to segment 1
Channel 3 belongs to segment 2
Segment 0 goes from LED 0 to 29
Segment 1 goes from LED 29 to 48
Total LED Count = 60
setSegment setBrightness: 0
ws2812fx.setSegment(0, 0, 29, 0, 00000000, 0, NO_OPTIONS)
setSegment setBrightness: 0
ws2812fx.setSegment(1, 29, 48, 0, 00000000, 0, NO_OPTIONS)
setSegment setBrightness: 0
ws2812fx.setSegment(2, 48, 57, 0, 00000000, 0, NO_OPTIONS)
ledCount for CH#1: 30
ledCount for CH#2: 20
ledCount for CH#3: 10
```


Debug output from the PR (with extra debugging)
```
calculateLedCount()
ch:0 seg:0 ledCnt:30 totLed:30 segStart:0 segEnd:29
ch:1 seg:1 ledCnt:20 totLed:50 segStart:30 segEnd:49
ch:2 seg:2 ledCnt:10 totLed:60 segStart:50 segEnd:59
SegNumber:2 SegCount:3
Channel 1 belongs to segment 0
Channel 2 belongs to segment 1
Channel 3 belongs to segment 2
Segment 0 goes from LED 0 to 29
Segment 1 goes from LED 30 to 49
Segment 2 goes from LED 50 to 59
Total LED Count = 60
setSegment setBrightness: 0
ws2812fx.setSegment(0, 0, 29, 0, 00000000, 0, NO_OPTIONS)
setSegment setBrightness: 0
ws2812fx.setSegment(1, 30, 49, 0, 00000000, 0, NO_OPTIONS)
setSegment setBrightness: 0
ws2812fx.setSegment(2, 50, 59, 0, 00000000, 0, NO_OPTIONS)
ledCount for CH#1: 30
ledCount for CH#2: 20
ledCount for CH#3: 10
```